### PR TITLE
[cuDNN] Add @cudnn.tensor.arg API for creating argument tensors

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "openxla-nvgpu/third_party/cudnn-frontend"]
+	path = openxla-nvgpu/third_party/cudnn-frontend
+	url = git@github.com:NVIDIA/cudnn-frontend.git

--- a/openxla-nvgpu/CMakeLists.txt
+++ b/openxla-nvgpu/CMakeLists.txt
@@ -12,6 +12,8 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 set(CMAKE_CXX_STANDARD 17)
 
+set(OPENXLA_NVGPU_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+
 # TODO: Fix this once the project is slotted into place.
 if(NOT IREE_ROOT_DIR)
   set(IREE_ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../iree")
@@ -43,3 +45,9 @@ iree_setup_toolchain()
 
 add_subdirectory(runtime)
 add_subdirectory(tools)
+
+#-------------------------------------------------------------------------------
+# NVIDIA dependencies
+#-------------------------------------------------------------------------------
+
+add_subdirectory(build_tools/third_party/cudnn-frontend EXCLUDE_FROM_ALL)

--- a/openxla-nvgpu/build_tools/third_party/cudnn-frontend/CMakeLists.txt
+++ b/openxla-nvgpu/build_tools/third_party/cudnn-frontend/CMakeLists.txt
@@ -1,0 +1,21 @@
+# Copyright 2023 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+set(CUDNN_FRONTEND_ROOT "${OPENXLA_NVGPU_ROOT_DIR}/third_party/cudnn-frontend/")
+
+external_cc_library(
+  PACKAGE
+    cudnn_frontend
+  NAME
+    cudnn_frontend
+  ROOT
+    ${CUDNN_FRONTEND_ROOT}
+  INCLUDES
+    "${CUDNN_FRONTEND_ROOT}/include"    
+  HDRS
+    "include/cudnn_frontend.h"
+  PUBLIC
+)

--- a/openxla-nvgpu/runtime/src/openxla/runtime/nvgpu/CMakeLists.txt
+++ b/openxla-nvgpu/runtime/src/openxla/runtime/nvgpu/CMakeLists.txt
@@ -25,7 +25,24 @@ iree_cc_library(
   DEPS
     ::defs
     ::dynamic_symbols
+    ::cudnn_tensor
     iree::runtime
+  PUBLIC
+)
+
+iree_cc_library(
+  NAME
+    cudnn_tensor
+  HDRS
+    "cudnn_tensor.h"
+  SRCS
+    "cudnn_tensor.cpp"
+  DEPS
+    ::defs
+    ::dynamic_symbols
+    ::cudnn_stub
+    cudnn_frontend
+    iree::vm
   PUBLIC
 )
 
@@ -50,5 +67,20 @@ iree_cc_library(
     # TODO: We rely on the fact that cuDNN headers are located in the same
     # directory as CUDA headers. Fix this.
     iree_cuda::headers
+  PUBLIC
+)
+
+iree_cc_library(
+  NAME
+    cudnn_stub
+  HDRS
+    "cudnn_stub.h"
+  TEXTUAL_HDRS
+    "cudnn_stub.h.inc"
+  SRCS
+    "cudnn_stub.cpp"
+  DEPS
+    ::defs
+    ::dynamic_symbols
   PUBLIC
 )

--- a/openxla-nvgpu/runtime/src/openxla/runtime/nvgpu/cudnn_module.cpp
+++ b/openxla-nvgpu/runtime/src/openxla/runtime/nvgpu/cudnn_module.cpp
@@ -8,9 +8,13 @@
 
 #include <iree/base/status.h>
 #include <iree/base/status_cc.h>
+#include <iree/vm/list.h>
 #include <iree/vm/ref_cc.h>
+#include <openxla/runtime/nvgpu/cudnn_tensor.h>
 
+#include <cstdint>
 #include <cstdio>
+#include <memory>
 
 #include "iree/hal/drivers/cuda/cuda_device.h"
 #include "iree/modules/hal/types.h"
@@ -32,10 +36,13 @@ class CuDNNModuleState {
   CuDNNModuleState(openxla_cudnn_dynamic_symbols_t syms, cudnnHandle_t handle);
   ~CuDNNModuleState();
 
-  Status Hello() {
-    fprintf(stderr, "Hello from OpenXLA CuDNN Module!\n");
-    return OkStatus();
-  }
+  // Creates a new tensor for cuDNN graph argument.
+  StatusOr<vm::ref<CuDNNTensor>> CreateTensorArg(
+      int64_t dtype, const vm::ref<iree_vm_list_t> dims, int64_t uid,
+      int64_t alignment);
+
+  // Prints tensor debug information to stderr.
+  Status PrintTensorDebug(const vm::ref<CuDNNTensor> tensor);
 
  private:
   CuDNNModuleState(const CuDNNModuleState&) = delete;
@@ -57,8 +64,51 @@ CuDNNModuleState::~CuDNNModuleState() {
   CUDNN_STATUS_CHECK_OK(&syms_, cudnnDestroy(handle_));
 }
 
+static StatusOr<cudnnDataType_t> ToCudnnDataType(int64_t dtype) {
+  if (dtype < CUDNN_DATA_FLOAT || dtype > CUDNN_DATA_FAST_FLOAT_FOR_FP8)
+    return Status(StatusCode::kInvalidArgument, "unsupported data type");
+  return static_cast<cudnnDataType_t>(dtype);
+}
+
+static StatusOr<std::vector<int64_t>> LoadI64Vec(const iree_vm_list_t* list) {
+  std::vector<int64_t> vector(iree_vm_list_size(list));
+  for (size_t i = 0; i < vector.size(); ++i) {
+    iree_vm_value_t value;
+    IREE_RETURN_IF_ERROR(
+        iree_vm_list_get_value_as(list, i, IREE_VM_VALUE_TYPE_I64, &value));
+    vector[i] = value.i64;
+  }
+  return vector;
+}
+
+static std::vector<int64_t> GetRowMajorStrides(span<const int64_t> dims) {
+  std::vector<int64_t> strides(dims.size(), 1);
+  for (int64_t i = dims.size() - 2; i >= 0; --i)
+    strides[i] = dims[i] * strides[i + 1];
+  return strides;
+}
+
+StatusOr<vm::ref<CuDNNTensor>> CuDNNModuleState::CreateTensorArg(
+    int64_t dtype, const vm::ref<iree_vm_list_t> dims, int64_t uid,
+    int64_t alignment) {
+  IREE_ASSIGN_OR_RETURN(cudnnDataType_t data_type, ToCudnnDataType(dtype));
+  IREE_ASSIGN_OR_RETURN(std::vector<int64_t> dimensions, LoadI64Vec(&*dims));
+  std::vector<int64_t> strides = GetRowMajorStrides(dimensions);
+  return CuDNNArgTensor::Create(&syms_, dimensions, strides, uid, data_type,
+                                alignment);
+}
+
+Status CuDNNModuleState::PrintTensorDebug(vm::ref<CuDNNTensor> tensor) {
+  // TODO: Add RTTI for CuDNN tensor types.
+  auto* arg = static_cast<CuDNNArgTensor*>(tensor.get());
+  std::string desc = arg->tensor().describe();
+  fprintf(stderr, "CuDNNArgTensor: %s\n", desc.c_str());
+  return OkStatus();
+}
+
 static const vm::NativeFunction<CuDNNModuleState> kCuDNNModuleFunctions[] = {
-    vm::MakeNativeFunction("hello", &CuDNNModuleState::Hello),
+    vm::MakeNativeFunction("tensor.arg", &CuDNNModuleState::CreateTensorArg),
+    vm::MakeNativeFunction("tensor.debug", &CuDNNModuleState::PrintTensorDebug),
 };
 
 //===----------------------------------------------------------------------===//
@@ -118,7 +168,17 @@ StatusOr<std::unique_ptr<CuDNNModuleState>> CuDNNModule::CreateState(
 // Register cuDNN module with IREE runtime.
 //===----------------------------------------------------------------------===//
 
-using namespace openxla::runtime::nvgpu;
+template <typename T>
+static iree_status_t RegisterType(iree_vm_ref_type_descriptor_t* descriptor,
+                                  const char* type_name) {
+  if (descriptor->type == IREE_VM_REF_TYPE_NULL) {
+    descriptor->type_name = iree_make_cstring_view(type_name);
+    descriptor->offsetof_counter = T::offsetof_counter();
+    descriptor->destroy = T::DirectDestroy;
+    return iree_vm_ref_register_type(descriptor);
+  }
+  return iree_ok_status();
+}
 
 extern "C" iree_status_t iree_custom_module_cudnn_create(
     iree_vm_instance_t* instance, iree_hal_device_t* device,
@@ -127,10 +187,16 @@ extern "C" iree_status_t iree_custom_module_cudnn_create(
 
   CUcontext cuda_ctx;
   IREE_RETURN_IF_ERROR(iree_hal_cuda_device_get_context(device, &cuda_ctx));
-
   auto module = std::make_unique<openxla::runtime::nvgpu::CuDNNModule>(
       instance, device, host_allocator, cuda_ctx);
   *out_module = module.release()->interface();
 
+  return iree_ok_status();
+}
+
+extern "C" iree_status_t iree_custom_module_cudnn_register_types(
+    iree_vm_instance_t* instance) {
+  IREE_RETURN_IF_ERROR(RegisterType<openxla::runtime::nvgpu::CuDNNTensor>(
+      &cudnn_tensor_descriptor, "cudnn.tensor"));
   return iree_ok_status();
 }

--- a/openxla-nvgpu/runtime/src/openxla/runtime/nvgpu/cudnn_module.h
+++ b/openxla-nvgpu/runtime/src/openxla/runtime/nvgpu/cudnn_module.h
@@ -20,6 +20,9 @@ iree_status_t iree_custom_module_cudnn_create(iree_vm_instance_t* instance,
                                               iree_allocator_t host_allocator,
                                               iree_vm_module_t** out_module);
 
+iree_status_t iree_custom_module_cudnn_register_types(
+    iree_vm_instance_t* instance);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/openxla-nvgpu/runtime/src/openxla/runtime/nvgpu/cudnn_stub.cpp
+++ b/openxla-nvgpu/runtime/src/openxla/runtime/nvgpu/cudnn_stub.cpp
@@ -1,0 +1,24 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "openxla/runtime/nvgpu/cudnn_stub.h"
+
+#include "openxla/runtime/nvgpu/dynamic_symbols.h"
+
+namespace openxla::runtime::nvgpu {
+
+static thread_local openxla_cudnn_dynamic_symbols_t* cudnn_syms = nullptr;
+
+ScopedCuDNNStubs::ScopedCuDNNStubs(openxla_cudnn_dynamic_symbols_t* syms)
+    : syms_(cudnn_syms) {
+  cudnn_syms = syms;
+}
+
+ScopedCuDNNStubs::~ScopedCuDNNStubs() { cudnn_syms = syms_; }
+
+openxla_cudnn_dynamic_symbols_t* ScopedCuDNNStubs::syms() { return cudnn_syms; }
+
+}  // namespace openxla::runtime::nvgpu

--- a/openxla-nvgpu/runtime/src/openxla/runtime/nvgpu/cudnn_stub.h
+++ b/openxla-nvgpu/runtime/src/openxla/runtime/nvgpu/cudnn_stub.h
@@ -1,0 +1,28 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef OPENXLA_RUNTIME_NVGPU_CUDNN_STUB_H_
+#define OPENXLA_RUNTIME_NVGPU_CUDNN_STUB_H_
+
+#include "openxla/runtime/nvgpu/dynamic_symbols.h"
+
+namespace openxla::runtime::nvgpu {
+
+// RAII helper to bind cuDNN stubs to dynamically resolved symbols.
+class ScopedCuDNNStubs {
+ public:
+  ScopedCuDNNStubs(openxla_cudnn_dynamic_symbols_t* syms);
+  ~ScopedCuDNNStubs();
+
+  static openxla_cudnn_dynamic_symbols_t* syms();
+
+ private:
+  openxla_cudnn_dynamic_symbols_t* syms_;
+};
+
+}  // namespace openxla::runtime::nvgpu
+
+#endif  // OPENXLA_RUNTIME_NVGPU_CUDNN_STUB_H_

--- a/openxla-nvgpu/runtime/src/openxla/runtime/nvgpu/cudnn_stub.h.inc
+++ b/openxla-nvgpu/runtime/src/openxla/runtime/nvgpu/cudnn_stub.h.inc
@@ -1,0 +1,52 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "openxla/runtime/nvgpu/cudnn_stub.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+//===----------------------------------------------------------------------===//
+// cuDNN API required for compiling cudnn_frontend.
+//===----------------------------------------------------------------------===//
+
+cudnnStatus_t CUDNNWINAPI
+cudnnBackendSetAttribute(cudnnBackendDescriptor_t descriptor,
+                         cudnnBackendAttributeName_t attributeName,
+                         cudnnBackendAttributeType_t attributeType,
+                         int64_t elementCount, const void* arrayOfElements) {
+  auto* syms = openxla::runtime::nvgpu::ScopedCuDNNStubs::syms();
+  IREE_ASSERT(syms);
+  return syms->cudnnBackendSetAttribute(
+      descriptor, attributeName, attributeType, elementCount, arrayOfElements);
+}
+
+cudnnStatus_t CUDNNWINAPI
+cudnnBackendCreateDescriptor(cudnnBackendDescriptorType_t descriptorType,
+                             cudnnBackendDescriptor_t* descriptor) {
+  auto* syms = openxla::runtime::nvgpu::ScopedCuDNNStubs::syms();
+  IREE_ASSERT(syms);
+  return syms->cudnnBackendCreateDescriptor(descriptorType, descriptor);
+}
+
+cudnnStatus_t CUDNNWINAPI
+cudnnBackendDestroyDescriptor(cudnnBackendDescriptor_t descriptor) {
+  auto* syms = openxla::runtime::nvgpu::ScopedCuDNNStubs::syms();
+  IREE_ASSERT(syms);
+  return syms->cudnnBackendDestroyDescriptor(descriptor);
+}
+
+cudnnStatus_t CUDNNWINAPI
+cudnnBackendFinalize(cudnnBackendDescriptor_t descriptor) {
+  auto* syms = openxla::runtime::nvgpu::ScopedCuDNNStubs::syms();
+  IREE_ASSERT(syms);
+  return syms->cudnnBackendFinalize(descriptor);
+}
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus

--- a/openxla-nvgpu/runtime/src/openxla/runtime/nvgpu/cudnn_tensor.cpp
+++ b/openxla-nvgpu/runtime/src/openxla/runtime/nvgpu/cudnn_tensor.cpp
@@ -1,0 +1,67 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "openxla/runtime/nvgpu/cudnn_tensor.h"
+
+#include <iree/base/internal/span.h>
+#include <iree/base/status.h>
+#include <iree/base/status_cc.h>
+#include <iree/vm/ref_cc.h>
+#include <openxla/runtime/nvgpu/status_util.h>
+
+#include "openxla/runtime/nvgpu/cudnn_stub.h"
+
+namespace openxla::runtime::nvgpu {
+
+using cudnn_frontend::TensorBuilder;
+
+using iree::span;
+using iree::StatusOr;
+using iree::vm::ref;
+
+// clang-format off
+#include "openxla/runtime/nvgpu/cudnn_stub.h.inc"
+// clang-format on
+
+//===----------------------------------------------------------------------===//
+// CuDNNArgTensor.
+//===----------------------------------------------------------------------===//
+
+StatusOr<ref<CuDNNTensor>> CuDNNArgTensor::Create(
+    openxla_cudnn_dynamic_symbols_t* syms, span<const int64_t> dims,
+    span<const int64_t> strides, int64_t uid, cudnnDataType_t dtype,
+    int64_t alignment) {
+  ScopedCuDNNStubs stubs(syms);
+  cudnn_frontend::Tensor tensor = cudnn_frontend::TensorBuilder()
+                                      .setDim(dims.size(), dims.data())
+                                      .setStride(strides.size(), strides.data())
+                                      .setId(uid)
+                                      .setAlignment(alignment)
+                                      .setDataType(dtype)
+                                      .build();
+  IREE_RETURN_IF_ERROR(CUDNN_CONVERT_STATUS(syms, tensor.get_status()));
+  return ref<CuDNNTensor>(new CuDNNArgTensor(syms, std::move(tensor)));
+}
+
+CuDNNArgTensor::CuDNNArgTensor(openxla_cudnn_dynamic_symbols_t* syms,
+                               cudnn_frontend::Tensor tensor)
+    : syms_(syms), tensor_(std::move(tensor)) {}
+
+CuDNNArgTensor::~CuDNNArgTensor() {
+  ScopedCuDNNStubs stubs(syms_);
+  tensor_.reset();
+}
+
+const cudnn_frontend::Tensor& CuDNNArgTensor::tensor() { return *tensor_; }
+
+}  // namespace openxla::runtime::nvgpu
+
+//===----------------------------------------------------------------------===//
+// Register types with IREE VM.
+//===----------------------------------------------------------------------===//
+
+IREE_VM_DEFINE_TYPE_ADAPTERS(cudnn_tensor,
+                             openxla::runtime::nvgpu::CuDNNTensor);

--- a/openxla-nvgpu/runtime/src/openxla/runtime/nvgpu/cudnn_tensor.h
+++ b/openxla-nvgpu/runtime/src/openxla/runtime/nvgpu/cudnn_tensor.h
@@ -1,0 +1,74 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef OPENXLA_RUNTIME_NVGPU_CUDNN_TENSOR_H_
+#define OPENXLA_RUNTIME_NVGPU_CUDNN_TENSOR_H_
+
+#define NV_CUDNN_DISABLE_EXCEPTION
+
+#include <cudnn_frontend.h>
+#include <iree/vm/ref_cc.h>
+
+#include <optional>
+
+#include "iree/base/internal/span.h"
+#include "iree/vm/api.h"
+#include "openxla/runtime/nvgpu/dynamic_symbols.h"
+
+namespace openxla::runtime::nvgpu {
+
+//===----------------------------------------------------------------------===//
+// cuDNN tensor representing an abstract shaped and typed block of memory.
+//===----------------------------------------------------------------------===//
+
+class CuDNNTensor : public iree::vm::RefObject<CuDNNTensor> {
+ public:
+  virtual ~CuDNNTensor() = default;
+};
+
+// TODO: We need a custom RTTI support for vm::ref data types to be able to
+// conveniently cast and dyn_cast to various tensor types.
+
+//===----------------------------------------------------------------------===//
+// Tensor corresponding to the cuDNN graph arguments.
+//===----------------------------------------------------------------------===//
+
+class CuDNNArgTensor final : public CuDNNTensor {
+ public:
+  static iree::StatusOr<iree::vm::ref<CuDNNTensor>> Create(
+      openxla_cudnn_dynamic_symbols_t* syms, iree::span<const int64_t> dims,
+      iree::span<const int64_t> strides, int64_t uid, cudnnDataType_t dtype,
+      int64_t alignment);
+
+  const cudnn_frontend::Tensor& tensor();
+
+ private:
+  CuDNNArgTensor(openxla_cudnn_dynamic_symbols_t* syms,
+                 cudnn_frontend::Tensor tensor);
+  ~CuDNNArgTensor() override;
+
+  openxla_cudnn_dynamic_symbols_t* syms_;
+  std::optional<cudnn_frontend::Tensor> tensor_;
+};
+
+//===----------------------------------------------------------------------===//
+// Tensor corresponding to the cuDNN operation result.
+//===----------------------------------------------------------------------===//
+
+// TODO: Tensor can be a result of cuDNN operation (think of MLIR BlockArgument
+// vs Value). CuDNNOpResultTensor has to carry tensor itself, and the operation
+// that produced it.
+
+}  // namespace openxla::runtime::nvgpu
+
+//===----------------------------------------------------------------------===//
+// Register types with IREE VM.
+//===----------------------------------------------------------------------===//
+
+IREE_VM_DECLARE_TYPE_ADAPTERS(cudnn_tensor,
+                              openxla::runtime::nvgpu::CuDNNTensor);
+
+#endif  // OPENXLA_RUNTIME_NVGPU_CUDNN_TENSOR_H_

--- a/openxla-nvgpu/runtime/src/openxla/runtime/nvgpu/dynamic_symbol_tables.h
+++ b/openxla-nvgpu/runtime/src/openxla/runtime/nvgpu/dynamic_symbol_tables.h
@@ -4,6 +4,22 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-CUDNN_PFN_DECL(cudnnCreate, cudnnHandle_t*)
+//===----------------------------------------------------------------------===//
+// Functions required for setting up cuDNN in CuDNNModule.
+//===----------------------------------------------------------------------===//
+
+CUDNN_PFN_DECL(cudnnCreate, cudnnHandle_t *)
 CUDNN_PFN_DECL(cudnnDestroy, cudnnHandle_t)
 CUDNN_PFN_DECL_STR_RETURN(cudnnGetErrorString)
+
+//===----------------------------------------------------------------------===//
+// Functions required for compiling cudnn_frontend (see cudnn_tensor.{h,cpp}).
+//===----------------------------------------------------------------------===//
+
+CUDNN_PFN_DECL(cudnnBackendFinalize, cudnnBackendDescriptor_t)
+CUDNN_PFN_DECL(cudnnBackendSetAttribute, cudnnBackendDescriptor_t,
+               cudnnBackendAttributeName_t, cudnnBackendAttributeType_t,
+               int64_t, const void *)
+CUDNN_PFN_DECL(cudnnBackendCreateDescriptor, cudnnBackendDescriptorType_t,
+               cudnnBackendDescriptor_t *)
+CUDNN_PFN_DECL(cudnnBackendDestroyDescriptor, cudnnBackendDescriptor_t)

--- a/openxla-nvgpu/runtime/src/openxla/runtime/nvgpu/dynamic_symbols.c
+++ b/openxla-nvgpu/runtime/src/openxla/runtime/nvgpu/dynamic_symbols.c
@@ -31,9 +31,17 @@ static iree_status_t openxla_cudnn_dynamic_symbols_resolve_all(
         syms->cudnn_library, kName, (void**)&syms->cuDNNSymbolName)); \
   }
 
+#define CUDNN_PFN_DECL_STR_RETURN(cuDNNSymbolName, ...)                          \
+  {                                                                   \
+    static const char* kName = #cuDNNSymbolName;                      \
+    IREE_RETURN_IF_ERROR(iree_dynamic_library_lookup_symbol(          \
+        syms->cudnn_library, kName, (void**)&syms->cuDNNSymbolName)); \
+  }  
+
 #include "openxla/runtime/nvgpu/dynamic_symbol_tables.h"  // IWYU pragma: export
 
 #undef CUDNN_PFN_DECL
+#undef CUDNN_PFN_DECL_STR_RETURN
   return iree_ok_status();
 }
 

--- a/openxla-nvgpu/runtime/src/openxla/runtime/nvgpu/dynamic_symbols.h
+++ b/openxla-nvgpu/runtime/src/openxla/runtime/nvgpu/dynamic_symbols.h
@@ -31,6 +31,7 @@ typedef struct openxla_cudnn_dynamic_symbols_t {
 #include "openxla/runtime/nvgpu/dynamic_symbol_tables.h"  // IWYU pragma: export
 
 #undef CUDNN_PFN_DECL
+#undef CUDNN_PFN_DECL_STR_RETURN
 } openxla_cudnn_dynamic_symbols_t;
 
 // Initializes |out_syms| in-place with dynamically loaded cuDNN symbols.

--- a/openxla-nvgpu/runtime/src/openxla/runtime/nvgpu/status_util.h
+++ b/openxla-nvgpu/runtime/src/openxla/runtime/nvgpu/status_util.h
@@ -19,7 +19,14 @@ extern "C" {
 // Converts a cudnnStatus_t to an iree_status_t.
 //
 // Usage:
-//   iree_status_t status = CUDNN_STATUS_TO_STATUS(cuDnnDoThing(...));
+//   iree_status_t status = CUDNN_CONVERT_STATUS(syms, cudnn_status);
+#define CUDNN_CONVERT_STATUS(syms, expr, ...) \
+  openxla_cudnn_status_to_status((syms), (expr), __FILE__, __LINE__)
+
+// Converts a cudnnStatus_t to an iree_status_t.
+//
+// Usage:
+//   iree_status_t status = CUDNN_STATUS_TO_STATUS(syms, cuDnnDoThing(...));
 #define CUDNN_STATUS_TO_STATUS(syms, expr, ...) \
   openxla_cudnn_status_to_status((syms), ((syms)->expr), __FILE__, __LINE__)
 
@@ -27,7 +34,7 @@ extern "C" {
 // to a iree_status_t.
 //
 // Usage:
-//   CUDNN_RETURN_IF_ERROR(cuDnnDoThing(...));
+//   CUDNN_RETURN_IF_ERROR(syms, cuDnnDoThing(...));
 #define CUDNN_RETURN_IF_ERROR(syms, expr, ...)                                \
   IREE_RETURN_IF_ERROR(openxla_cudnn_status_to_status((syms), ((syms)->expr), \
                                                       __FILE__, __LINE__),    \
@@ -37,7 +44,7 @@ extern "C" {
 // iree_status_t.
 //
 // Usage:
-//   CUDNN_STATUS_CHECK_OK(cuDnnDoThing(...));
+//   CUDNN_STATUS_CHECK_OK(syms, cuDnnDoThing(...));
 #define CUDNN_STATUS_CHECK_OK(syms, expr, ...)                         \
   IREE_CHECK_OK(openxla_cudnn_status_to_status((syms), ((syms)->expr), \
                                                __FILE__, __LINE__))

--- a/openxla-nvgpu/tools/openxla-runner.c
+++ b/openxla-nvgpu/tools/openxla-runner.c
@@ -38,6 +38,10 @@ int main(int argc, char** argv) {
   IREE_CHECK_OK(iree_runtime_instance_create(&instance_options, host_allocator,
                                              &instance));
 
+  // Register custom types define by cuDNN module.
+  IREE_CHECK_OK(iree_custom_module_cudnn_register_types(
+      iree_runtime_instance_vm_instance(instance)));
+
   // Try to create the CUDA device.
   iree_hal_device_t* device = NULL;
   IREE_CHECK_OK(iree_runtime_instance_try_create_default_device(
@@ -70,9 +74,8 @@ int main(int argc, char** argv) {
   }
 
   iree_string_view_t entry_point = iree_make_cstring_view(argv[2]);
-  fprintf(stdout, "INVOKE BEGIN %.*s\n", (int)entry_point.size,
+  fprintf(stderr, "INVOKE BEGIN %.*s\n", (int)entry_point.size,
           entry_point.data);
-  fflush(stdout);
 
   iree_vm_list_t* inputs = NULL;
   IREE_CHECK_OK(iree_vm_list_create(NULL, 1, host_allocator, &inputs));
@@ -83,8 +86,7 @@ int main(int argc, char** argv) {
   IREE_CHECK_OK(
       iree_runtime_session_call_by_name(session, entry_point, inputs, outputs));
 
-  fprintf(stdout, "INVOKE END %.*s\n", (int)entry_point.size, entry_point.data);
-  fflush(stdout);
+  fprintf(stderr, "INVOKE END %.*s\n", (int)entry_point.size, entry_point.data);
 
   iree_vm_list_release(inputs);
   iree_vm_list_release(outputs);


### PR DESCRIPTION
1. Add dependency on `cudnn_frontend`
2. Create stubs for calling cuDNN via dynamically loaded symbols
3. Register CuDNNTensor type with an IREE VM
4. Simple end-to-end-example creating a single tensor